### PR TITLE
Fix help output

### DIFF
--- a/modules/help.py
+++ b/modules/help.py
@@ -17,7 +17,7 @@ class Help(commands.Cog):
 
         embed.add_field(
             name="💖 Affirmations",
-            value="`/affirm`, `/comfort`, `/dailyhype`",
+            value="`/affirm`, `/dailyhype`",
             inline=False
         )
         embed.add_field(


### PR DESCRIPTION
## Summary
- update help listing to reflect actual commands

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6882cdd79f5083278cc71756e9d3b84f