### PR TITLE
Add license and improve README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 The BinkoBot Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # BinkoBot
-See full documentation in project.
+
+BinkoBot is a modular Discord companion bot focused on cozy vibes and small community use. The bot uses slash commands and can be customized through its configuration file and environment variables.
+
+## Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone <repo-url>
+   cd BinkoBot
+   ```
+2. **Create a virtual environment (optional but recommended)**
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+3. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. **Configure the bot**
+   - Adjust `config.json` if you need to change the command prefix or other defaults.
+   - Set the required environment variables described below.
+
+## Environment Variables
+
+- `DISCORD_TOKEN` – **required**. Your bot token from the [Discord Developer Portal](https://discord.com/developers/applications).
+- `DEV_GUILD_ID` – optional. If set, slash commands sync to this guild first for faster updates.
+- `REPLIT` – set to `1` when running on Replit so the keep-alive web server starts.
+- `LEGACY_MODE` – set to `1` to enable some legacy prefix commands such as `!ping`.
+
+You can export these variables in your shell or place them in an `.env` file and load them using `python-dotenv` if preferred.
+
+## Running the Bot
+
+Once dependencies and environment variables are set, start BinkoBot with:
+
+```bash
+python main.py
+```
+
+The bot will register slash commands on startup. If `DEV_GUILD_ID` is provided, commands appear in that guild immediately; otherwise, global registration may take up to an hour.
+
+See `privacy_policy.md` for details on how the bot handles data.


### PR DESCRIPTION
## Summary
- add MIT license
- document setup instructions and environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6882ce7dbb0c83278eb394ca2829ee60