### PR TITLE
Configure flake8 and add basic test

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+extend-ignore = E302,E501,E722,F401,W292
+max-line-length = 127

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ BinkoBotProject/generated-icon.png
 *.env
 
 **/__pycache__/
+.pytest_cache/

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,7 @@
+import json
+
+
+def test_config_has_prefix():
+    with open('config.json', encoding='utf-8') as f:
+        config = json.load(f)
+    assert config.get('prefix') is not None


### PR DESCRIPTION
## Summary
- add flake8 configuration ignoring common style warnings
- ignore pytest cache in `.gitignore`
- add a simple pytest checking `config.json`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882c3e76da483278e87a9e8f64fe54d