### PR TITLE
Improve environment variable loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ BinkoBot is a modular Discord companion bot focused on cozy vibes and small comm
 4. **Configure the bot**
    - Adjust `config.json` if you need to change the command prefix or other defaults.
    - Set the required environment variables described below.
+   - Optionally store them in a `.env` file for automatic loading.
 
 ## Environment Variables
 
@@ -29,7 +30,8 @@ BinkoBot is a modular Discord companion bot focused on cozy vibes and small comm
 - `REPLIT` – set to `1` when running on Replit so the keep-alive web server starts.
 - `LEGACY_MODE` – set to `1` to enable some legacy prefix commands such as `!ping`.
 
-You can export these variables in your shell or place them in an `.env` file and load them using `python-dotenv` if preferred.
+You can export these variables in your shell or simply place them in an `.env` file.
+`main.py` automatically loads this file using `python-dotenv` on startup.
 
 ## Running the Bot
 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,9 @@ import asyncio
 import logging
 from discord.ext import commands
 from keep_alive import keep_alive
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Logging setup
 logging.basicConfig(
@@ -56,9 +59,17 @@ async def on_ready():
     await load_all_extensions()
 
     try:
+        if DEV_GUILD_ID:
+            dev_guild = discord.Object(id=int(DEV_GUILD_ID))
+            dev_synced = await bot.tree.sync(guild=dev_guild)
+            logging.info(
+                f"🔁 Slash commands synced to DEV_GUILD_ID {DEV_GUILD_ID}: {len(dev_synced)}"
+            )
         bot.tree.clear_commands(guild=None)
         synced = await bot.tree.sync()
-        logging.info(f"🔁 Slash commands forcibly re-synced globally: {len(synced)}")
+        logging.info(
+            f"🔁 Slash commands forcibly re-synced globally: {len(synced)}"
+        )
 
         for command in bot.tree.get_commands():
             logging.info(f"📋 Registered slash command: /{command.name} – {command.description}")


### PR DESCRIPTION
## Summary
- auto-load environment variables from a `.env` file in `main.py`
- sync slash commands to `DEV_GUILD_ID` when provided
- document `.env` file usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882da6a090c8327b6fc71dc50ebc070