### PR TITLE
Add analytics toggle via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ BinkoBot is a modular Discord companion bot focused on cozy vibes and small comm
 - `DEV_GUILD_ID` – optional. If set, slash commands sync to this guild first for faster updates.
 - `REPLIT` – set to `1` when running on Replit so the keep-alive web server starts.
 - `LEGACY_MODE` – set to `1` to enable some legacy prefix commands such as `!ping`.
+- `ANALYTICS_ENABLED` – set to `0` to disable command usage analytics.
 
 You can export these variables in your shell or simply place them in an `.env` file.
 `main.py` automatically loads this file using `python-dotenv` on startup.

--- a/privacy_policy.md
+++ b/privacy_policy.md
@@ -26,7 +26,13 @@ BinkoBot is a modular Discord companion bot designed for cozy, adaptive, and per
 - When authorized by you, BinkoBot may:
   - Read your public playlist to recommend songs matching mood
   - Never accesses private listening history or modifies your Spotify account
-  - Tokens are stored only during active use and discarded immediately after
+- Tokens are stored only during active use and discarded immediately after
+
+#### 📊 Usage Analytics *(Optional)*
+- Records which commands are used and when
+- Stored locally in `data/analytics.json`
+- Only used for the `/stats` command so you can view your top commands
+- Set `ANALYTICS_ENABLED=0` before launching the bot to disable this logging
 
 ---
 


### PR DESCRIPTION
## Summary
- add `ANALYTICS_ENABLED` environment variable
- gate usage logging and `/stats` command behind the new flag
- update privacy policy with analytics details
- document the env var in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f8ab2568832795087894f762b3e5