### PR TITLE
Add trigger monitoring

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ initial_extensions = [
     "modules.help",
     "modules.responder",
     "modules.locked",
+    "modules.mental_support",
 ]
 
 # Optional Dev Guild for faster slash command registration

--- a/modules/mental_support.py
+++ b/modules/mental_support.py
@@ -1,1 +1,47 @@
-# mental_support.py logic placeholder
+import discord
+from discord.ext import commands
+import json
+import random
+import os
+
+
+class MentalSupport(commands.Cog):
+    """Detect concerning phrases and offer gentle support via DM."""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+        with open("data/trigger_keywords.json", "r", encoding="utf-8") as f:
+            self.keywords = [k.lower() for k in json.load(f)]
+
+        with open("data/trigger_responses.txt", "r", encoding="utf-8") as f:
+            self.responses = [line.strip() for line in f if line.strip()]
+
+    def contains_trigger(self, text: str) -> bool:
+        """Return True if the text contains a trigger keyword."""
+        lower = text.lower()
+        return any(kw in lower for kw in self.keywords)
+
+    def get_response(self) -> str:
+        return random.choice(self.responses)
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.author.bot or not message.content:
+            return
+
+        if self.contains_trigger(message.content):
+            reply = self.get_response()
+
+            try:
+                if isinstance(message.channel, discord.DMChannel):
+                    await message.channel.send(reply)
+                else:
+                    await message.author.send(reply)
+            except discord.Forbidden:
+                pass
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(MentalSupport(bot))
+

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from modules.mental_support import MentalSupport
+
+class DummyBot:
+    pass
+
+def test_contains_trigger_true():
+    cog = MentalSupport(DummyBot())
+    assert cog.contains_trigger("I want to die")
+
+def test_contains_trigger_false():
+    cog = MentalSupport(DummyBot())
+    assert not cog.contains_trigger("Just saying hi")


### PR DESCRIPTION
## Summary
- implement `MentalSupport` cog listening for concerning phrases
- load new cog in the extension list
- make `modules` a package so tests can import it
- unit tests for trigger detection logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f9c3fb808327ba366baf9125d192