### PR TITLE
Add goodnight & emojiattack commands

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ initial_extensions = [
     "modules.mood_with_roles",
     "modules.touch",
     "modules.lore",
+    "modules.goodnight",
     "modules.privacy",
     "modules.dm_toggle",
     "modules.help",

--- a/modules/goodnight.py
+++ b/modules/goodnight.py
@@ -1,0 +1,26 @@
+import discord
+from discord.ext import commands
+from discord import app_commands
+import random
+from utils.sender import send_private_or_public
+
+class Goodnight(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        with open("data/sleep_wishes.txt", "r", encoding="utf-8") as f:
+            self.sleep_lines = [line.strip() for line in f if line.strip()]
+        with open("data/emoji_attacks.txt", "r", encoding="utf-8") as f:
+            self.attack_lines = [line.strip() for line in f if line.strip()]
+
+    @app_commands.command(name="goodnight", description="Send a cozy goodnight wish")
+    async def goodnight(self, interaction: discord.Interaction):
+        line = random.choice(self.sleep_lines)
+        await send_private_or_public(interaction, line)
+
+    @app_commands.command(name="emojiattack", description="Unleash a chaotic emoji attack")
+    async def emojiattack(self, interaction: discord.Interaction):
+        line = random.choice(self.attack_lines)
+        await send_private_or_public(interaction, line)
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(Goodnight(bot))

--- a/modules/help.py
+++ b/modules/help.py
@@ -17,7 +17,7 @@ class Help(commands.Cog):
 
         embed.add_field(
             name="💖 Affirmations",
-            value="`/affirm`, `/dailyhype`",
+            value="`/affirm`, `/dailyhype`, `/goodnight`, `/emojiattack`",
             inline=False
         )
         embed.add_field(

--- a/utils/sender.py
+++ b/utils/sender.py
@@ -11,21 +11,43 @@ def load_dm_preferences():
         return json.load(f)
 
 async def send_private_or_public(ctx, message, file=None):
+    """Send a message respecting a user's DM preference.
+
+    ``ctx`` may be either a ``commands.Context`` or ``discord.Interaction``.
+    ``message`` is the content to send and ``file`` an optional file attachment.
+    """
+
     prefs = load_dm_preferences()
-    uid = str(ctx.author.id)
-    send_dm = prefs.get(uid, False)
+
+    user = getattr(ctx, "author", None) or getattr(ctx, "user", None)
+    if user is None:
+        raise TypeError("ctx must be a commands.Context or discord.Interaction")
+
+    send_dm = prefs.get(str(user.id), False)
+
+    async def send_channel(msg, file=None):
+        if hasattr(ctx, "send"):
+            await ctx.send(msg, file=file)
+        elif hasattr(ctx, "response"):
+            if not ctx.response.is_done():
+                await ctx.response.send_message(msg, file=file)
+            else:
+                await ctx.followup.send(msg, file=file)
 
     try:
         if send_dm:
             if file:
-                await ctx.author.send(message, file=file)
+                await user.send(message, file=file)
             else:
-                await ctx.author.send(message)
+                await user.send(message)
+
+            if hasattr(ctx, "response"):
+                if not ctx.response.is_done():
+                    await ctx.response.send_message("📩 Sent in DMs", ephemeral=True)
+                else:
+                    await ctx.followup.send("📩 Sent in DMs", ephemeral=True)
         else:
-            if file:
-                await ctx.send(message, file=file)
-            else:
-                await ctx.send(message)
+            await send_channel(message, file)
     except discord.Forbidden:
-        await ctx.send("I tried to DM you but couldn’t~ Here’s your message publicly instead.")
-        await ctx.send(message)
+        await send_channel("I tried to DM you but couldn’t~ Here’s your message publicly instead.")
+        await send_channel(message, file)


### PR DESCRIPTION
## Summary
- create new goodnight module with `/goodnight` and `/emojiattack`
- support interactions in `send_private_or_public`
- load the new cog and update help embed

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882fb601b5c8327b0096d4e31a99406