### PR TITLE
Add configurable logging controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ Each key in this file tweaks a piece of BinkoBot's behavior:
   purged automatically.
 - `allow_lewd_in_cozyspace_only` – Restricts lewd commands to cozyspace
   channels and DMs.
-- `logging.enabled` – Toggles log output to the console.
-- `logging.log_flags_only` – If enabled, only logs flagged events rather than
-  every message.
+- `logging.enabled` – When `false`, regular log messages are suppressed and only
+  warnings/errors are shown.
+- `logging.log_flags_only` – If `true`, only log records marked with
+  `extra={"flagged": True}` will be printed.
 
 ## Running the Bot
 

--- a/main.py
+++ b/main.py
@@ -10,22 +10,40 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-# Logging setup
-logging.basicConfig(
-    level=logging.INFO,
-    format='[%(asctime)s] [%(levelname)s] %(message)s',
-    handlers=[logging.StreamHandler()]
-)
-
-# Intents setup
-intents = discord.Intents.default()
-intents.message_content = True
-
 # Load configuration
 with open("config.json", "r", encoding="utf-8") as f:
     config = json.load(f)
 
+logging_cfg = config.get("logging", {})
+logging_enabled = logging_cfg.get("enabled", True)
+log_flags_only = logging_cfg.get("log_flags_only", False)
+
 prefix = config.get("prefix", "!")
+
+# Logging setup
+if logging_enabled:
+    logging.basicConfig(
+        level=logging.INFO,
+        format='[%(asctime)s] [%(levelname)s] %(message)s',
+        handlers=[logging.StreamHandler()]
+    )
+    if log_flags_only:
+        class FlagOnlyFilter(logging.Filter):
+            def filter(self, record: logging.LogRecord) -> bool:
+                return getattr(record, "flagged", False)
+
+        for handler in logging.getLogger().handlers:
+            handler.addFilter(FlagOnlyFilter())
+else:
+    logging.basicConfig(
+        level=logging.WARNING,
+        format='[%(asctime)s] [%(levelname)s] %(message)s',
+        handlers=[logging.StreamHandler()]
+    )
+
+# Intents setup
+intents = discord.Intents.default()
+intents.message_content = True
 
 # Bot setup
 bot = commands.Bot(command_prefix=prefix, intents=intents, help_command=None)

--- a/modules/mental_support.py
+++ b/modules/mental_support.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 import json
 import random
 import os
+import logging
 
 
 class MentalSupport(commands.Cog):
@@ -31,6 +32,10 @@ class MentalSupport(commands.Cog):
             return
 
         if self.contains_trigger(message.content):
+            logging.info(
+                f"Flagged mental health phrase from {message.author}: {message.content}",
+                extra={"flagged": True},
+            )
             reply = self.get_response()
 
             try:


### PR DESCRIPTION
## Summary
- allow disabling or filtering log output via `config.json`
- flag mental health triggers with log records
- document the new logging behavior

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882fe2befa883278e3d96febf6c7e1e