### PR TITLE
Add coverage for new commands and analytics toggle

### DIFF
--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import modules.analytics as analytics
+
+class DummyBot:
+    pass
+
+
+def test_analytics_disabled(monkeypatch):
+    monkeypatch.setenv('ANALYTICS_ENABLED', '0')
+    monkeypatch.setattr(analytics.os.path, 'exists', lambda _p: True)
+    cog = analytics.Analytics(DummyBot())
+    assert not cog.analytics_enabled

--- a/tests/test_goodnight.py
+++ b/tests/test_goodnight.py
@@ -1,0 +1,17 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from modules.goodnight import Goodnight
+from discord import app_commands
+
+class DummyBot:
+    pass
+
+
+def test_goodnight_commands_register():
+    cog = Goodnight(DummyBot())
+    command_names = {cmd.name for cmd in cog.__cog_app_commands__}
+    assert 'goodnight' in command_names
+    assert 'emojiattack' in command_names


### PR DESCRIPTION
## Summary
- test that new goodnight & emojiattack commands load
- test analytics can be disabled via env variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882ff152d9c8327afc8eb76a4dcc916