### PR TITLE
Add music voice playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ BinkoBot is a modular Discord companion bot focused on cozy vibes and small comm
 - `REPLIT` – set to `1` when running on Replit so the keep-alive web server starts.
 - `LEGACY_MODE` – set to `1` to enable some legacy prefix commands such as `!ping`.
 - `ANALYTICS_ENABLED` – set to `0` to disable command usage analytics.
+- `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` – optional. Required if you
+  want to play Spotify track links through the new music player.
 
 You can export these variables in your shell or simply place them in an `.env` file.
 `main.py` automatically loads this file using `python-dotenv` on startup.
@@ -65,5 +67,16 @@ python main.py
 ```
 
 The bot will register slash commands on startup. If `DEV_GUILD_ID` is provided, commands appear in that guild immediately; otherwise, global registration may take up to an hour.
+
+## Voice & Music
+
+BinkoBot can join a voice channel and play music from YouTube links, search terms, or Spotify track URLs. Spotify support requires the `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` environment variables. You also need `ffmpeg` installed on your system for audio playback.
+
+Commands:
+
+- `/join` – Have the bot join your current voice channel.
+- `/play <query>` – Play a YouTube link, search term, or Spotify track.
+- `/stop` – Stop the current track.
+- `/leave` – Disconnect from the voice channel.
 
 See `privacy_policy.md` for details on how the bot handles data.

--- a/main.py
+++ b/main.py
@@ -65,6 +65,7 @@ initial_extensions = [
     "modules.privacy",
     "modules.dm_toggle",
     "modules.help",
+    "modules.music_player",
     "modules.responder",
     "modules.locked",
     "modules.mental_support",

--- a/modules/help.py
+++ b/modules/help.py
@@ -42,7 +42,7 @@ class Help(commands.Cog):
         )
         embed.add_field(
             name="🎧 Tools & Stats",
-            value="`/music`, `/stats`, `/help`",
+            value="`/join`, `/play`, `/stop`, `/leave`, `/music`, `/stats`, `/help`",
             inline=False
         )
 

--- a/modules/mental_support.py
+++ b/modules/mental_support.py
@@ -49,4 +49,3 @@ class MentalSupport(commands.Cog):
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(MentalSupport(bot))
-

--- a/modules/music_player.py
+++ b/modules/music_player.py
@@ -1,0 +1,122 @@
+import discord
+from discord.ext import commands
+from discord import app_commands
+import yt_dlp
+import spotipy
+from spotipy.oauth2 import SpotifyClientCredentials
+import os
+
+
+class MusicPlayer(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.voice_clients = {}
+        self.spotify = None
+        if os.getenv("SPOTIFY_CLIENT_ID") and os.getenv("SPOTIFY_CLIENT_SECRET"):
+            creds = SpotifyClientCredentials()
+            self.spotify = spotipy.Spotify(client_credentials_manager=creds)
+
+        self.ytdl_opts = {
+            "format": "bestaudio/best",
+            "noplaylist": True,
+            "quiet": True,
+            "default_search": "ytsearch1",
+        }
+        self.ytdl = yt_dlp.YoutubeDL(self.ytdl_opts)
+
+    async def ensure_voice(self, interaction: discord.Interaction):
+        guild_id = interaction.guild.id
+        vc = self.voice_clients.get(guild_id)
+        if vc and vc.is_connected():
+            return vc
+
+        if not interaction.user.voice:
+            await interaction.response.send_message(
+                "You're not in a voice channel.", ephemeral=True
+            )
+            return None
+
+        vc = await interaction.user.voice.channel.connect()
+        self.voice_clients[guild_id] = vc
+        return vc
+
+    def get_youtube_source(self, query: str):
+        data = self.ytdl.extract_info(query, download=False)
+        if "entries" in data:
+            data = data["entries"][0]
+        return data["url"], data.get("title", "Unknown")
+
+    def get_spotify_query(self, url: str):
+        if not self.spotify:
+            return None
+        parts = url.split("/")
+        if "track" in parts:
+            track_id = parts[-1].split("?")[0]
+            track = self.spotify.track(track_id)
+            name = track["name"]
+            artist = track["artists"][0]["name"]
+            return f"{name} {artist}"
+        return None
+
+    @app_commands.command(name="join", description="Join your voice channel")
+    async def join(self, interaction: discord.Interaction):
+        if not interaction.user.voice:
+            await interaction.response.send_message(
+                "You're not in a voice channel.", ephemeral=True
+            )
+            return
+
+        vc = await interaction.user.voice.channel.connect()
+        self.voice_clients[interaction.guild.id] = vc
+        await interaction.response.send_message(
+            f"Connected to {interaction.user.voice.channel}", ephemeral=True
+        )
+
+    @app_commands.command(name="play", description="Play music from YouTube or Spotify")
+    @app_commands.describe(query="YouTube link, Spotify track link, or search term")
+    async def play(self, interaction: discord.Interaction, query: str):
+        vc = await self.ensure_voice(interaction)
+        if not vc:
+            return
+
+        if "spotify.com" in query:
+            spotify_query = self.get_spotify_query(query)
+            if spotify_query:
+                query = spotify_query
+
+        url, title = self.get_youtube_source(query)
+        vc.play(discord.FFmpegPCMAudio(url))
+        await interaction.response.send_message(
+            f"▶️ Now playing: {title}", ephemeral=True
+        )
+
+    @app_commands.command(name="stop", description="Stop the current track")
+    async def stop(self, interaction: discord.Interaction):
+        vc = self.voice_clients.get(interaction.guild.id)
+        if vc and vc.is_playing():
+            vc.stop()
+            await interaction.response.send_message(
+                "⏹️ Stopped playback.", ephemeral=True
+            )
+        else:
+            await interaction.response.send_message(
+                "Nothing is playing.", ephemeral=True
+            )
+
+    @app_commands.command(name="leave", description="Disconnect from the voice channel")
+    async def leave(self, interaction: discord.Interaction):
+        vc = self.voice_clients.get(interaction.guild.id)
+        if vc:
+            await vc.disconnect()
+            await interaction.response.send_message(
+                "👋 Left the voice channel.", ephemeral=True
+            )
+            del self.voice_clients[interaction.guild.id]
+        else:
+            await interaction.response.send_message(
+                "I\'m not in a voice channel.", ephemeral=True
+            )
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(MusicPlayer(bot))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ python-dotenv
 typing_extensions
 async-timeout
 flask
+yt-dlp
+spotipy

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-import modules.analytics as analytics
+import modules.analytics as analytics  # noqa: E402
 
 class DummyBot:
     pass

--- a/tests/test_goodnight.py
+++ b/tests/test_goodnight.py
@@ -3,8 +3,8 @@ import os
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from modules.goodnight import Goodnight
-from discord import app_commands
+from modules.goodnight import Goodnight  # noqa: E402
+from discord import app_commands  # noqa: E402
 
 class DummyBot:
     pass

--- a/tests/test_music_player.py
+++ b/tests/test_music_player.py
@@ -1,0 +1,11 @@
+import importlib
+
+
+def test_music_player_loads():
+    module = importlib.import_module('modules.music_player')
+
+    class DummyBot:
+        pass
+
+    cog = module.MusicPlayer(DummyBot())
+    assert isinstance(cog, module.MusicPlayer)

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from modules.mental_support import MentalSupport
+from modules.mental_support import MentalSupport  # noqa: E402
 
 class DummyBot:
     pass


### PR DESCRIPTION
## Summary
- implement `music_player` cog for joining voice channels and playing audio
- load the new cog in `main.py`
- expand help message and README
- document Spotify environment variables
- update requirements with music dependencies
- add basic test for `music_player`
- fix existing tests and flake8 linting issues

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68830075b714832793ae063ba7c70362