### PR TITLE
Add WholesomeChaos cog

### DIFF
--- a/data/chaos_lines.txt
+++ b/data/chaos_lines.txt
@@ -1,0 +1,5 @@
+Let's cause trouble and blame the gremlins.
+Chaos is just creativity wearing mismatched socks.
+Who needs sleep when we can wreak havoc?
+I'm 90% caffeine and 10% questionable choices.
+Prepare for some delightful disaster!

--- a/data/wholesome_lines.txt
+++ b/data/wholesome_lines.txt
@@ -1,0 +1,5 @@
+You're wonderful just as you are.
+I hope your day is as lovely as you.
+Remember to drink water and breathe deeply.
+Your kindness makes the world brighter.
+Sending a big virtual hug your way!

--- a/main.py
+++ b/main.py
@@ -70,6 +70,7 @@ initial_extensions = [
     "modules.responder",
     "modules.locked",
     "modules.mental_support",
+    "modules.wholesome_chaos",
 ]
 
 # Optional Dev Guild for faster slash command registration

--- a/modules/wholesome_chaos.py
+++ b/modules/wholesome_chaos.py
@@ -1,1 +1,28 @@
-# wholesome_chaos.py logic placeholder
+import discord
+from discord.ext import commands
+from discord import app_commands
+import random
+from utils.sender import send_private_or_public
+
+
+class WholesomeChaos(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        with open("data/wholesome_lines.txt", "r", encoding="utf-8") as f:
+            self.wholesome_lines = [line.strip() for line in f if line.strip()]
+        with open("data/chaos_lines.txt", "r", encoding="utf-8") as f:
+            self.chaos_lines = [line.strip() for line in f if line.strip()]
+
+    @app_commands.command(name="wholesome", description="Send a wholesome line")
+    async def wholesome(self, interaction: discord.Interaction):
+        line = random.choice(self.wholesome_lines)
+        await send_private_or_public(interaction, line)
+
+    @app_commands.command(name="chaos", description="Send a chaotic line")
+    async def chaos(self, interaction: discord.Interaction):
+        line = random.choice(self.chaos_lines)
+        await send_private_or_public(interaction, line)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(WholesomeChaos(bot))

--- a/tests/test_wholesome_chaos.py
+++ b/tests/test_wholesome_chaos.py
@@ -1,0 +1,18 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from modules.wholesome_chaos import WholesomeChaos  # noqa: E402
+from discord import app_commands  # noqa: E402
+
+
+class DummyBot:
+    pass
+
+
+def test_wholesome_chaos_commands_register():
+    cog = WholesomeChaos(DummyBot())
+    command_names = {cmd.name for cmd in cog.__cog_app_commands__}
+    assert 'wholesome' in command_names
+    assert 'chaos' in command_names


### PR DESCRIPTION
## Summary
- implement `WholesomeChaos` cog providing `/wholesome` and `/chaos`
- create text files for wholesome and chaotic lines
- register the cog in `main.py`
- add tests confirming slash command registration

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688304edaebc8327b94190a36c3e93b2