### PR TITLE
Add personality toggle cog

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,6 +101,7 @@ initial_extensions = [
     "modules.mental_support",
     "modules.wholesome_chaos",
     "modules.nightmode",
+    "modules.enhanced_personality",
 ]
 
 # Optional Dev Guild for faster slash command registration

--- a/modules/enhanced_personality.py
+++ b/modules/enhanced_personality.py
@@ -1,1 +1,69 @@
-# enhanced_personality.py logic placeholder
+import discord
+from discord.ext import commands
+from discord import app_commands
+import json
+import os
+
+CONFIG_FILE = "config.json"
+
+
+def load_config():
+    with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_config(cfg):
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+
+
+def is_personality_enabled() -> bool:
+    try:
+        cfg = load_config()
+    except FileNotFoundError:
+        return True
+    return cfg.get("enhanced_personality_enabled", True)
+
+
+def set_personality_enabled(state: bool) -> None:
+    try:
+        cfg = load_config()
+    except FileNotFoundError:
+        cfg = {}
+    cfg["enhanced_personality_enabled"] = state
+    save_config(cfg)
+
+
+class EnhancedPersonality(commands.Cog):
+    """Toggle the bot's enhanced personality mode."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.enabled = is_personality_enabled()
+
+    personality_group = app_commands.Group(
+        name="personality", description="Manage enhanced personality"
+    )
+
+    @personality_group.command(name="on", description="Enable enhanced personality")
+    async def personality_on(self, interaction: discord.Interaction):
+        set_personality_enabled(True)
+        self.enabled = True
+        await interaction.response.send_message(
+            "Enhanced personality enabled.", ephemeral=True
+        )
+
+    @personality_group.command(name="off", description="Disable enhanced personality")
+    async def personality_off(self, interaction: discord.Interaction):
+        set_personality_enabled(False)
+        self.enabled = False
+        await interaction.response.send_message(
+            "Enhanced personality disabled.", ephemeral=True
+        )
+
+    async def cog_app_command_group(self):
+        return [self.personality_group]
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(EnhancedPersonality(bot))

--- a/modules/goodnight.py
+++ b/modules/goodnight.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 from discord import app_commands
 import random
 from utils.sender import send_private_or_public
+from modules.enhanced_personality import is_personality_enabled
 
 class Goodnight(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -14,12 +15,18 @@ class Goodnight(commands.Cog):
 
     @app_commands.command(name="goodnight", description="Send a cozy goodnight wish")
     async def goodnight(self, interaction: discord.Interaction):
-        line = random.choice(self.sleep_lines)
+        if is_personality_enabled():
+            line = random.choice(self.sleep_lines)
+        else:
+            line = "Goodnight."  # simpler message when personality is off
         await send_private_or_public(interaction, line)
 
     @app_commands.command(name="emojiattack", description="Unleash a chaotic emoji attack")
     async def emojiattack(self, interaction: discord.Interaction):
-        line = random.choice(self.attack_lines)
+        if is_personality_enabled():
+            line = random.choice(self.attack_lines)
+        else:
+            line = "💥"
         await send_private_or_public(interaction, line)
 
 async def setup(bot: commands.Bot):

--- a/tests/test_enhanced_personality.py
+++ b/tests/test_enhanced_personality.py
@@ -1,0 +1,27 @@
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from modules import enhanced_personality as ep  # noqa: E402
+
+class DummyBot:
+    pass
+
+
+def test_toggle_persists(tmp_path):
+    cfg = tmp_path / "config.json"
+    with open(cfg, "w", encoding="utf-8") as f:
+        json.dump({}, f)
+
+    ep.CONFIG_FILE = str(cfg)
+    cog = ep.EnhancedPersonality(DummyBot())
+
+    ep.set_personality_enabled(True)
+    assert ep.is_personality_enabled()
+    assert cog.enabled
+
+    ep.set_personality_enabled(False)
+    assert not ep.is_personality_enabled()
+


### PR DESCRIPTION
## Summary
- implement enhanced personality cog with `/personality on` and `/personality off`
- adjust `goodnight` responses based on personality state
- register the new cog in `main.py`
- test toggling persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883076e03c483278fe71a59c35b50c0